### PR TITLE
feat: add JMS scanner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>javax.ejb</groupId>
+            <artifactId>javax.ejb-api</artifactId>
+            <version>3.2.2</version>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <version>2.1.1</version>

--- a/src/main/java/com/hlag/tools/commvis/domain/model/AbstractCommunicationModelVisitor.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/model/AbstractCommunicationModelVisitor.java
@@ -4,5 +4,6 @@ package com.hlag.tools.commvis.domain.model;
  * The visitor pattern to transform the internal model.
  */
 public abstract class AbstractCommunicationModelVisitor {
-    public abstract void visit(HttpEndpoint httpEndpoint);
+    public abstract void visit(HttpEndpoint endpoint);
+    public abstract void visit(JmsEndpoint endpoint);
 }

--- a/src/main/java/com/hlag/tools/commvis/domain/model/IEndpoint.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/model/IEndpoint.java
@@ -2,8 +2,6 @@ package com.hlag.tools.commvis.domain.model;
 
 public interface IEndpoint {
     String getClassName();
-    String getMethodName();
-    String getType();
 
     void visit(AbstractCommunicationModelVisitor visitor);
 }

--- a/src/main/java/com/hlag/tools/commvis/domain/model/JmsEndpoint.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/model/JmsEndpoint.java
@@ -1,0 +1,23 @@
+package com.hlag.tools.commvis.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@AllArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode
+public class JmsEndpoint implements IEndpoint {
+    private String className;
+    // e.g. "javax.jms.Queue"
+    private String destinationType;
+    // e.g. "jms/catalogs/customer"
+    private String destination;
+
+    @Override
+    public void visit(AbstractCommunicationModelVisitor visitor) {
+        visitor.visit(this);
+    }
+}

--- a/src/main/java/com/hlag/tools/commvis/domain/port/out/DotCommunicationModelVisitor.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/port/out/DotCommunicationModelVisitor.java
@@ -3,6 +3,7 @@ package com.hlag.tools.commvis.domain.port.out;
 import com.hlag.tools.commvis.domain.model.AbstractCommunicationModelVisitor;
 import com.hlag.tools.commvis.domain.model.CommunicationModel;
 import com.hlag.tools.commvis.domain.model.HttpEndpoint;
+import com.hlag.tools.commvis.domain.model.JmsEndpoint;
 import org.springframework.stereotype.Component;
 
 /**
@@ -20,9 +21,19 @@ public class DotCommunicationModelVisitor extends AbstractCommunicationModelVisi
     }
 
     @Override
-    public void visit(HttpEndpoint httpEndpoint) {
-        String label = httpEndpoint.getClassName() + "." + httpEndpoint.getMethodName() + "\\n" + httpEndpoint.getPath() + "\\n" + httpEndpoint.getType();
-        nodeDefinitions.append(String.format("  \"%d\" [label=\"%s\"]\n", nodes, label));
+    public void visit(HttpEndpoint endpoint) {
+        String label = endpoint.getClassName() + "." + endpoint.getMethodName() + "\\n" + endpoint.getPath() + "\\n" + endpoint.getType();
+        nodeDefinitions.append(String.format("  \"%d\" [label=\"%s\";shape=\"ellipse\"]\n", nodes, label));
+
+        graphDefinitions.append(String.format("  \"%d\" -> \"application\"\n", nodes));
+
+        ++nodes;
+    }
+
+    @Override
+    public void visit(JmsEndpoint endpoint) {
+        String label = endpoint.getClassName() + "\\n" + endpoint.getDestination() + "\\n" + endpoint.getDestinationType();
+        nodeDefinitions.append(String.format("  \"%d\" [label=\"%s\";shape=\"diamond\"]\n", nodes, label));
 
         graphDefinitions.append(String.format("  \"%d\" -> \"application\"\n", nodes));
 

--- a/src/main/java/com/hlag/tools/commvis/service/IEndpointScannerService.java
+++ b/src/main/java/com/hlag/tools/commvis/service/IEndpointScannerService.java
@@ -2,11 +2,11 @@ package com.hlag.tools.commvis.service;
 
 import com.hlag.tools.commvis.domain.model.IEndpoint;
 
-import java.util.Set;
+import java.util.Collection;
 
 /**
  * Scans the classpath for endpoints which allow incoming communication.
  */
 public interface IEndpointScannerService {
-    Set<IEndpoint> scanClasspath(String rootPackageName);
+    Collection<IEndpoint> scanClasspath(String rootPackageName);
 }

--- a/src/main/java/com/hlag/tools/commvis/service/JaxRsEndpointScannerImpl.java
+++ b/src/main/java/com/hlag/tools/commvis/service/JaxRsEndpointScannerImpl.java
@@ -7,7 +7,6 @@ import org.reflections.scanners.Scanners;
 import org.springframework.stereotype.Service;
 
 import javax.ws.rs.*;
-import javax.ws.rs.core.Application;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -15,12 +14,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.reflections.scanners.Scanners.MethodsAnnotated;
-import static org.reflections.scanners.Scanners.SubTypes;
 
+/**
+ * Scans the classpath for JMS endpoints.
+ */
 @Service
 public class JaxRsEndpointScannerImpl implements IEndpointScannerService {
     @Override
-    public Set<IEndpoint> scanClasspath(String rootPackageName) {
+    public Collection<IEndpoint> scanClasspath(String rootPackageName) {
         Set<IEndpoint> endpoints = new HashSet<>();
         List<Class<? extends Annotation>> httpMethodsToScan = Arrays.asList(DELETE.class, GET.class, HEAD.class, OPTIONS.class, PATCH.class, POST.class, PUT.class);
 

--- a/src/main/java/com/hlag/tools/commvis/service/JmsEndpointScannerImpl.java
+++ b/src/main/java/com/hlag/tools/commvis/service/JmsEndpointScannerImpl.java
@@ -1,0 +1,44 @@
+package com.hlag.tools.commvis.service;
+
+import com.hlag.tools.commvis.domain.model.IEndpoint;
+import com.hlag.tools.commvis.domain.model.JmsEndpoint;
+import org.reflections.Reflections;
+import org.reflections.scanners.Scanners;
+import org.springframework.stereotype.Service;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.reflections.scanners.Scanners.TypesAnnotated;
+
+@Service
+public class JmsEndpointScannerImpl implements IEndpointScannerService {
+    @Override
+    public Collection<IEndpoint> scanClasspath(String rootPackageName) {
+        Set<IEndpoint> endpoints = new HashSet<>();
+
+        Reflections reflections = new Reflections(rootPackageName, Scanners.values());
+        Set<Class<?>> classes = reflections.get(TypesAnnotated.with(MessageDriven.class).asClass());
+
+        classes.forEach(c -> {
+            MessageDriven[] annotation = c.getDeclaredAnnotationsByType(MessageDriven.class);
+            String destinationType = null;
+            String destination = null;
+
+            for (ActivationConfigProperty config : annotation[0].activationConfig()) {
+                if ("destinationType".equals(config.propertyName())) {
+                    destinationType = config.propertyValue();
+                } else if ("destination".equals(config.propertyName())) {
+                    destination = config.propertyValue();
+                }
+            }
+
+            endpoints.add(new JmsEndpoint(c.getCanonicalName(), destinationType, destination));
+        });
+
+        return endpoints;
+    }
+}

--- a/src/test/java/com/hlag/tools/commvis/service/JaxRsEndpointScannerImplTest.java
+++ b/src/test/java/com/hlag/tools/commvis/service/JaxRsEndpointScannerImplTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.HttpMethod;
+import java.util.Collection;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,16 +21,16 @@ class JaxRsEndpointScannerImplTest {
 
     @Test
     void shouldFindEndpointsForAllHttpMethods_whenScanClasspath() {
-        Set<IEndpoint> actualEndpoints = clazz.scanClasspath("test.jaxrs");
+        Collection<HttpEndpoint> actualEndpoints = (Collection) clazz.scanClasspath("test.jaxrs");
 
-        assertThat(actualEndpoints).extracting(IEndpoint::getType).containsExactlyInAnyOrder(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST, HttpMethod.DELETE, HttpMethod.PUT, HttpMethod.OPTIONS, HttpMethod.PATCH);
+        assertThat(actualEndpoints).extracting(HttpEndpoint::getType).containsExactlyInAnyOrder(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST, HttpMethod.DELETE, HttpMethod.PUT, HttpMethod.OPTIONS, HttpMethod.PATCH);
     }
 
     @Test
     void shouldExtractAllEndpointInformation_whenScanClasspath() {
-        IEndpoint expectedEndpoint = new HttpEndpoint("test.jaxrs.Endpoints", "receivesAPostRequest", "POST", "endpoint/a");
+        HttpEndpoint expectedEndpoint = new HttpEndpoint("test.jaxrs.Endpoints", "receivesAPostRequest", "POST", "endpoint/a");
 
-        Set<IEndpoint> actualEndpoints = clazz.scanClasspath("test.jaxrs");
+        Collection<HttpEndpoint> actualEndpoints = (Collection) clazz.scanClasspath("test.jaxrs");
 
         assertThat(actualEndpoints).contains(expectedEndpoint);
     }

--- a/src/test/java/com/hlag/tools/commvis/service/JmsEndpointScannerImplTest.java
+++ b/src/test/java/com/hlag/tools/commvis/service/JmsEndpointScannerImplTest.java
@@ -1,0 +1,35 @@
+package com.hlag.tools.commvis.service;
+
+import com.hlag.tools.commvis.domain.model.JmsEndpoint;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JmsEndpointScannerImplTest {
+    private JmsEndpointScannerImpl clazz;
+
+    @BeforeEach
+    void init() {
+        this.clazz = new JmsEndpointScannerImpl();
+    }
+
+    @Test
+    void shouldFindJmsReceivers_whenScanClasspath() {
+        Collection<JmsEndpoint> actualEndpoints = (Collection) clazz.scanClasspath("test.jms");
+
+        Assertions.assertThat(actualEndpoints).size().isEqualTo(1);
+    }
+
+    @Test
+    void shouldExtractAllEndpointInformation_whenScanClasspath() {
+        JmsEndpoint expectedEndpoint = new JmsEndpoint("test.jms.CustomerCancelledOrderReceiver", "javax.jms.Queue", "jms/customer/orderCancelled");
+
+        Collection<JmsEndpoint> actualEndpoints = (Collection) clazz.scanClasspath("test.jms");
+
+        assertThat(actualEndpoints).contains(expectedEndpoint);
+    }
+}

--- a/src/test/java/integration/endpoint/CustomerCancelledOrderReceiver.java
+++ b/src/test/java/integration/endpoint/CustomerCancelledOrderReceiver.java
@@ -1,0 +1,8 @@
+package integration.endpoint;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+
+@MessageDriven(name = "CustomerCancelledOrderReceiver", activationConfig = {@ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"), @ActivationConfigProperty(propertyName = "destination", propertyValue = "jms/customer/orderCancelled"), @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge")})
+public class CustomerCancelledOrderReceiver {
+}

--- a/src/test/java/test/jms/CustomerCancelledOrderReceiver.java
+++ b/src/test/java/test/jms/CustomerCancelledOrderReceiver.java
@@ -1,0 +1,8 @@
+package test.jms;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+
+@MessageDriven(name = "CustomerCancelledOrderReceiver", activationConfig = {@ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"), @ActivationConfigProperty(propertyName = "destination", propertyValue = "jms/customer/orderCancelled"), @ActivationConfigProperty(propertyName = "acknowledgeMode", propertyValue = "Auto-acknowledge")})
+public class CustomerCancelledOrderReceiver {
+}

--- a/src/test/resources/model/integration-model.dot
+++ b/src/test/resources/model/integration-model.dot
@@ -1,12 +1,13 @@
 digraph G {
-  "0" [label="integration.endpoint.CustomerEndpoint.deleteCustomer\nsales/customers/{customerId}\nDELETE"]
-  "1" [label="integration.endpoint.CustomerEndpoint.createCustomer\nsales/customers\nPOST"]
-  "2" [label="integration.endpoint.CustomerEndpoint.readCustomer\nsales/customers/{customerId}\nGET"]
-  "3" [label="integration.endpoint.CustomerEndpoint.updateCustomer\nsales/customers/{customerId}\nPUT"]
-  "application" [shape=box]
+  "0" [label="integration.endpoint.CustomerEndpoint.deleteCustomer\nsales/customers/{customerId}\nDELETE";shape="ellipse"]
+  "1" [label="integration.endpoint.CustomerCancelledOrderReceiver\njms/customer/orderCancelled\njavax.jms.Queue";shape="diamond"]
+  "2" [label="integration.endpoint.CustomerEndpoint.createCustomer\nsales/customers\nPOST";shape="ellipse"]
+  "3" [label="integration.endpoint.CustomerEndpoint.readCustomer\nsales/customers/{customerId}\nGET";shape="ellipse"]
+  "4" [label="integration.endpoint.CustomerEndpoint.updateCustomer\nsales/customers/{customerId}\nPUT";shape="ellipse"]
 
   "0" -> "application"
   "1" -> "application"
   "2" -> "application"
   "3" -> "application"
+  "4" -> "application"
 }

--- a/src/test/resources/model/integration-model.json
+++ b/src/test/resources/model/integration-model.json
@@ -25,5 +25,12 @@
       "type": "PUT",
       "path": "sales/customers/{customerId}"
     }
+  ],
+  "jms_endpoints": [
+    {
+      "class_name": "integration.endpoint.CustomerCancelledOrderReceiver",
+      "destination": "jms/customer/orderCancelled",
+      "destination_type": "javax.jms.Queue"
+    }
   ]
 }


### PR DESCRIPTION
# Description

Scans all classes for JMS message receivers. They are shown as diamond in the graph and places under `jms_endpoints` in the model.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
