### PR TITLE
feat: add project id and name to the model

### DIFF
--- a/src/main/java/com/hlag/tools/commvis/domain/command/ScannerCommand.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/command/ScannerCommand.java
@@ -2,7 +2,6 @@ package com.hlag.tools.commvis.domain.command;
 
 import com.hlag.tools.commvis.domain.model.CommunicationModel;
 import com.hlag.tools.commvis.domain.model.IEndpoint;
-import com.hlag.tools.commvis.service.ExportModelJsonServiceImpl;
 import com.hlag.tools.commvis.service.IEndpointScannerService;
 import com.hlag.tools.commvis.service.IExportModelService;
 import lombok.extern.slf4j.Slf4j;
@@ -10,8 +9,8 @@ import org.springframework.stereotype.Component;
 import picocli.CommandLine;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.Callable;
 
 @Slf4j
@@ -21,8 +20,14 @@ public class ScannerCommand implements Callable<Integer> {
     private final IEndpointScannerService[] scannerServices;
     private final IExportModelService[] exportModelServices;
 
-    @CommandLine.Parameters(index = "0", description = "The root package to analyze (including all sub packages)")
+    @CommandLine.Parameters(index = "1", description = "The root package to analyze (including all sub packages)")
     private String rootPackageName;
+
+    @CommandLine.Parameters(index = "0", description = "ID of the project to be analyzed. Used to link projects.")
+    private String projectId;
+
+    @CommandLine.Option(names = {"-n", "--name"}, defaultValue = "application", description = "Name of the project to be analyzed.")
+    private String projectName;
 
     public ScannerCommand(IEndpointScannerService[] scannerServices, IExportModelService[] exportModelServices) {
         this.scannerServices = scannerServices;
@@ -30,11 +35,11 @@ public class ScannerCommand implements Callable<Integer> {
     }
 
     @Override
-    public Integer call() throws Exception {
-        Set<IEndpoint> endpoints = new HashSet<>();
+    public Integer call() {
+        Collection<IEndpoint> endpoints = new HashSet<>();
         Arrays.asList(scannerServices).forEach(s -> endpoints.addAll(s.scanClasspath(rootPackageName)));
 
-        CommunicationModel model = new CommunicationModel(endpoints);
+        CommunicationModel model = new CommunicationModel(projectId, projectName, endpoints);
         Arrays.asList(exportModelServices).forEach(s -> s.export(model, "model"));
 
         log.info(String.valueOf(endpoints));

--- a/src/main/java/com/hlag/tools/commvis/domain/model/AbstractCommunicationModelVisitor.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/model/AbstractCommunicationModelVisitor.java
@@ -4,6 +4,8 @@ package com.hlag.tools.commvis.domain.model;
  * The visitor pattern to transform the internal model.
  */
 public abstract class AbstractCommunicationModelVisitor {
+    public abstract void visit(CommunicationModel model);
+
     public abstract void visit(HttpEndpoint endpoint);
     public abstract void visit(JmsEndpoint endpoint);
 }

--- a/src/main/java/com/hlag/tools/commvis/domain/model/CommunicationModel.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/model/CommunicationModel.java
@@ -2,6 +2,7 @@ package com.hlag.tools.commvis.domain.model;
 
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.ToString;
 
 import java.util.Collection;
@@ -13,9 +14,15 @@ import java.util.Collection;
 @ToString
 @EqualsAndHashCode
 public class CommunicationModel {
+    @Getter
+    private String projectId;
+    @Getter
+    private String projectName;
     private Collection<IEndpoint> endpoints;
 
     public void visit(AbstractCommunicationModelVisitor visitor) {
+        visitor.visit(this);
+
         endpoints.forEach(e -> e.visit(visitor));
     }
 }

--- a/src/main/java/com/hlag/tools/commvis/domain/port/out/DotCommunicationModelVisitor.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/port/out/DotCommunicationModelVisitor.java
@@ -21,9 +21,14 @@ public class DotCommunicationModelVisitor extends AbstractCommunicationModelVisi
     }
 
     @Override
+    public void visit(CommunicationModel model) {
+        nodeDefinitions.append(String.format("  \"application\" [label=\"%s\" shape=\"rectangle\"]\n", model.getProjectName()));
+    }
+
+    @Override
     public void visit(HttpEndpoint endpoint) {
         String label = endpoint.getClassName() + "." + endpoint.getMethodName() + "\\n" + endpoint.getPath() + "\\n" + endpoint.getType();
-        nodeDefinitions.append(String.format("  \"%d\" [label=\"%s\";shape=\"ellipse\"]\n", nodes, label));
+        nodeDefinitions.append(String.format("  \"%d\" [label=\"%s\" shape=\"ellipse\"]\n", nodes, label));
 
         graphDefinitions.append(String.format("  \"%d\" -> \"application\"\n", nodes));
 
@@ -33,7 +38,7 @@ public class DotCommunicationModelVisitor extends AbstractCommunicationModelVisi
     @Override
     public void visit(JmsEndpoint endpoint) {
         String label = endpoint.getClassName() + "\\n" + endpoint.getDestination() + "\\n" + endpoint.getDestinationType();
-        nodeDefinitions.append(String.format("  \"%d\" [label=\"%s\";shape=\"diamond\"]\n", nodes, label));
+        nodeDefinitions.append(String.format("  \"%d\" [label=\"%s\" shape=\"diamond\"]\n", nodes, label));
 
         graphDefinitions.append(String.format("  \"%d\" -> \"application\"\n", nodes));
 

--- a/src/main/java/com/hlag/tools/commvis/domain/port/out/JsonCommunicationModelVisitor.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/port/out/JsonCommunicationModelVisitor.java
@@ -3,6 +3,7 @@ package com.hlag.tools.commvis.domain.port.out;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.hlag.tools.commvis.domain.model.AbstractCommunicationModelVisitor;
+import com.hlag.tools.commvis.domain.model.CommunicationModel;
 import com.hlag.tools.commvis.domain.model.HttpEndpoint;
 import com.hlag.tools.commvis.domain.model.JmsEndpoint;
 import lombok.extern.slf4j.Slf4j;
@@ -22,13 +23,19 @@ public class JsonCommunicationModelVisitor extends AbstractCommunicationModelVis
     private String version;
     private StringBuilder httpEndpointsJson = new StringBuilder();
     private StringBuilder jmsEndpointsJson = new StringBuilder();
+    private StringBuilder modelSettings = new StringBuilder();
 
     public JsonCommunicationModelVisitor(@Value("${git.tags}") String gitTag) {
         this.version = gitTag;
     }
 
     public String getJson() {
-        return String.format("{\"version\": \"%s\", \"http_endpoints\": [%s], \"jms_endpoints\": [%s]}", version, httpEndpointsJson, jmsEndpointsJson);
+        return String.format("{%s, \"http_endpoints\": [%s], \"jms_endpoints\": [%s]}", modelSettings, httpEndpointsJson, jmsEndpointsJson);
+    }
+
+    @Override
+    public void visit(CommunicationModel model) {
+        modelSettings.append(String.format("\"version\": \"%s\", \"id\": \"%s\", \"name\": \"%s\"", version, model.getProjectId(), model.getProjectName()));
     }
 
     @Override

--- a/src/test/java/com/hlag/tools/commvis/domain/command/ScannerCommandIT.java
+++ b/src/test/java/com/hlag/tools/commvis/domain/command/ScannerCommandIT.java
@@ -32,7 +32,7 @@ class ScannerCommandIT {
     void shouldMatchCurrentModel_whenWriteJson() throws Exception {
         String expectedJson = contentOf(new File("src/test/resources/model/integration-model.json"));
 
-        new CommandLine(new ScannerCommand(scannerServices, exportModelServices)).execute("-n=my-project", "4711", "integration");
+        new CommandLine(new ScannerCommand(scannerServices, exportModelServices)).execute("--name=my-project", "4711", "integration");
 
         File actualJsonFile = new File("model.json");
 
@@ -44,7 +44,7 @@ class ScannerCommandIT {
     void shouldMatchCurrentModel_whenWriteDot() {
         String expectedDot = contentOf(new File("src/test/resources/model/integration-model.dot"));
 
-        new CommandLine(new ScannerCommand(scannerServices, exportModelServices)).execute("-n my-project", "4711", "integration");
+        new CommandLine(new ScannerCommand(scannerServices, exportModelServices)).execute("-n", "my-project", "4711", "integration");
 
         File currentDotFile = new File("model.dot");
 

--- a/src/test/java/com/hlag/tools/commvis/domain/command/ScannerCommandIT.java
+++ b/src/test/java/com/hlag/tools/commvis/domain/command/ScannerCommandIT.java
@@ -4,7 +4,6 @@ import com.hlag.tools.commvis.domain.adapter.PropertyFilesConfiguration;
 import com.hlag.tools.commvis.domain.port.out.DotCommunicationModelVisitor;
 import com.hlag.tools.commvis.domain.port.out.JsonCommunicationModelVisitor;
 import com.hlag.tools.commvis.service.*;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
@@ -18,7 +17,6 @@ import java.io.File;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
 
-@Slf4j
 @SpringBootTest(classes = {JaxRsEndpointScannerImpl.class, ScannerCommand.class, ExportModelJsonServiceImpl.class, ExportModelDotServiceImpl.class, PropertyFilesConfiguration.class, JsonCommunicationModelVisitor.class, DotCommunicationModelVisitor.class, JmsEndpointScannerImpl.class})
 class ScannerCommandIT {
     @Autowired
@@ -32,22 +30,21 @@ class ScannerCommandIT {
 
     @Test
     void shouldMatchCurrentModel_whenWriteJson() throws Exception {
-        String expectedJson=contentOf(new File("src/test/resources/model/integration-model.json"));
+        String expectedJson = contentOf(new File("src/test/resources/model/integration-model.json"));
 
-        new CommandLine(new ScannerCommand(scannerServices, exportModelServices)).execute("integration");
+        new CommandLine(new ScannerCommand(scannerServices, exportModelServices)).execute("-n=my-project", "4711", "integration");
 
         File actualJsonFile = new File("model.json");
 
-      log.info(contentOf(actualJsonFile));
         assertThat(actualJsonFile).exists().isFile().canRead();
         JSONAssert.assertEquals(expectedJson.replace("###version###", modelVersion), contentOf(actualJsonFile), JSONCompareMode.STRICT);
     }
 
     @Test
     void shouldMatchCurrentModel_whenWriteDot() {
-        String expectedDot=contentOf(new File("src/test/resources/model/integration-model.dot"));
+        String expectedDot = contentOf(new File("src/test/resources/model/integration-model.dot"));
 
-        new CommandLine(new ScannerCommand(scannerServices, exportModelServices)).execute("integration");
+        new CommandLine(new ScannerCommand(scannerServices, exportModelServices)).execute("-n my-project", "4711", "integration");
 
         File currentDotFile = new File("model.dot");
 

--- a/src/test/java/com/hlag/tools/commvis/domain/command/ScannerCommandTest.java
+++ b/src/test/java/com/hlag/tools/commvis/domain/command/ScannerCommandTest.java
@@ -1,6 +1,5 @@
 package com.hlag.tools.commvis.domain.command;
 
-import com.hlag.tools.commvis.service.ExportModelJsonServiceImpl;
 import com.hlag.tools.commvis.service.IEndpointScannerService;
 import com.hlag.tools.commvis.service.IExportModelService;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,10 +12,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ScannerCommandTest {
     @Mock
-    private IEndpointScannerService scannerService;
-
-    @Mock
     IExportModelService exportModelServices;
+    @Mock
+    private IEndpointScannerService scannerService;
 
     @BeforeEach
     public void init() {
@@ -24,15 +22,22 @@ class ScannerCommandTest {
     }
 
     @Test
-    void shouldAcceptThePackageName_whenCalledFromCommandLine() throws Exception {
-        int actualExitCode = new CommandLine(new ScannerCommand(new IEndpointScannerService[] {scannerService}, new IExportModelService[] {exportModelServices})).execute("com.hlag");
+    void shouldAcceptProjectIdAndPackageName_whenCalledFromCommandLine() {
+        int actualExitCode = new CommandLine(new ScannerCommand(new IEndpointScannerService[]{scannerService}, new IExportModelService[]{exportModelServices})).execute("4711", "com.hlag");
 
-        assertThat(actualExitCode).isEqualTo(0);
+        assertThat(actualExitCode).isZero();
     }
 
     @Test
-    void shouldExitWithStatusCode2_whenCalledFromCommandLine_givenNoPackageName() throws Exception {
-        int actualExitCode = new CommandLine(new ScannerCommand(new IEndpointScannerService[] {scannerService}, new IExportModelService[] {exportModelServices})).execute();
+    void shouldExitWithStatusCode2_whenCalledFromCommandLine_givenNoParameters() {
+        int actualExitCode = new CommandLine(new ScannerCommand(new IEndpointScannerService[]{scannerService}, new IExportModelService[]{exportModelServices})).execute();
+
+        assertThat(actualExitCode).isEqualTo(2);
+    }
+
+    @Test
+    void shouldExitWithStatusCode2_whenCalledFromCommandLine_givenProjectIdOnly() {
+        int actualExitCode = new CommandLine(new ScannerCommand(new IEndpointScannerService[]{scannerService}, new IExportModelService[]{exportModelServices})).execute("4711");
 
         assertThat(actualExitCode).isEqualTo(2);
     }

--- a/src/test/java/com/hlag/tools/commvis/domain/port/out/JsonCommunicationModelVisitorTest.java
+++ b/src/test/java/com/hlag/tools/commvis/domain/port/out/JsonCommunicationModelVisitorTest.java
@@ -26,7 +26,7 @@ class JsonCommunicationModelVisitorTest {
         givenHttpEndpoints.add(new HttpEndpoint("classname", "methodname", "type", "path"));
         givenHttpEndpoints.add(new HttpEndpoint("classname1", "methodname1", "type1", "path1"));
 
-        CommunicationModel givenModel = new CommunicationModel(givenHttpEndpoints);
+        CommunicationModel givenModel = new CommunicationModel("4711", "my-project", givenHttpEndpoints);
 
         Assertions.assertThatNoException().isThrownBy(() -> {
             givenModel.visit(jsonCommunicationModelVisitor);

--- a/src/test/resources/model/integration-model.dot
+++ b/src/test/resources/model/integration-model.dot
@@ -1,5 +1,5 @@
 digraph G {
-  "application" [label="application" shape="rectangle"]
+  "application" [label="my-project" shape="rectangle"]
   "0" [label="integration.endpoint.CustomerEndpoint.deleteCustomer\nsales/customers/{customerId}\nDELETE" shape="ellipse"]
   "1" [label="integration.endpoint.CustomerCancelledOrderReceiver\njms/customer/orderCancelled\njavax.jms.Queue" shape="diamond"]
   "2" [label="integration.endpoint.CustomerEndpoint.createCustomer\nsales/customers\nPOST" shape="ellipse"]

--- a/src/test/resources/model/integration-model.dot
+++ b/src/test/resources/model/integration-model.dot
@@ -1,9 +1,10 @@
 digraph G {
-  "0" [label="integration.endpoint.CustomerEndpoint.deleteCustomer\nsales/customers/{customerId}\nDELETE";shape="ellipse"]
-  "1" [label="integration.endpoint.CustomerCancelledOrderReceiver\njms/customer/orderCancelled\njavax.jms.Queue";shape="diamond"]
-  "2" [label="integration.endpoint.CustomerEndpoint.createCustomer\nsales/customers\nPOST";shape="ellipse"]
-  "3" [label="integration.endpoint.CustomerEndpoint.readCustomer\nsales/customers/{customerId}\nGET";shape="ellipse"]
-  "4" [label="integration.endpoint.CustomerEndpoint.updateCustomer\nsales/customers/{customerId}\nPUT";shape="ellipse"]
+  "application" [label="application" shape="rectangle"]
+  "0" [label="integration.endpoint.CustomerEndpoint.deleteCustomer\nsales/customers/{customerId}\nDELETE" shape="ellipse"]
+  "1" [label="integration.endpoint.CustomerCancelledOrderReceiver\njms/customer/orderCancelled\njavax.jms.Queue" shape="diamond"]
+  "2" [label="integration.endpoint.CustomerEndpoint.createCustomer\nsales/customers\nPOST" shape="ellipse"]
+  "3" [label="integration.endpoint.CustomerEndpoint.readCustomer\nsales/customers/{customerId}\nGET" shape="ellipse"]
+  "4" [label="integration.endpoint.CustomerEndpoint.updateCustomer\nsales/customers/{customerId}\nPUT" shape="ellipse"]
 
   "0" -> "application"
   "1" -> "application"

--- a/src/test/resources/model/integration-model.json
+++ b/src/test/resources/model/integration-model.json
@@ -1,5 +1,7 @@
 {
   "version": "###version###",
+  "id": "4711",
+  "name": "my-project",
   "http_endpoints": [
     {
       "class_name": "integration.endpoint.CustomerEndpoint",


### PR DESCRIPTION
# Description

Add the project id (CLI parameter 1) and the project name (`-n name` or `--name=name`; optional and defaults to `application`) to the command line interface. The root package name has been moved to parameter 2.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
