### PR TITLE
ci: copy JARs from Maven submodules to release folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 target/
 node_modules/
+release/
 
 *.iml
 model.json

--- a/.release/prepare-release.sh
+++ b/.release/prepare-release.sh
@@ -13,4 +13,7 @@ mvn versions:set -DnewVersion=$JAR_VERSION
 # Package the new library version and copy it to release folder
 # These files will be upload to github by @semantic-release/github
 mvn package
-mkdir release && cp target/*.jar release
+
+# copy files to release folder which is published on Github
+mkdir release
+find . -maxdepth 3 -name "*.jar" -exec cp {} release/ \;


### PR DESCRIPTION
# Description

As we have Maven submodules now, we have to copy the JARs to  release from the `target` folder of the submodule.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
