### PR TITLE
fix: improve error handling if classpath is incomplete

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.hlag.tools.commvis</groupId>
     <artifactId>distcommvis</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Distributed Communication Visualizer</name>
     <url>https://github.com/Hapag-Lloyd/dist-comm-vis</url>

--- a/src/main/java/com/hlag/tools/commvis/domain/service/JaxRsEndpointScannerImpl.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/service/JaxRsEndpointScannerImpl.java
@@ -45,12 +45,24 @@ public class JaxRsEndpointScannerImpl implements IScannerService {
         methods.forEach(m -> {
             VisualizeHttpsCall visualizeAnnotation = m.getDeclaredAnnotation(VisualizeHttpsCall.class);
 
+            //as we found methods with the Annotation we must get a result here
+            if (visualizeAnnotation == null) {
+                log.error("Unable to find the annotation, but we found a method with the annotation. Make sure that the classpath contains all relevant libraries for your application.");
+                throw new IllegalStateException("VisualizeHttpCall annotation could not be read!");
+            }
+
             endpoints.add(createHttpProducer(visualizeAnnotation, m));
         });
 
         methods = reflections.get(MethodsAnnotated.with(VisualizeHttpsCalls.class).as(Method.class));
         methods.forEach(m -> {
             VisualizeHttpsCalls visualizeAnnotations = m.getDeclaredAnnotation(VisualizeHttpsCalls.class);
+
+            //as we found methods with the Annotation we must get a result here
+            if (visualizeAnnotations == null) {
+                log.error("Unable to find the annotation, but we found a method with the annotation. Make sure that the classpath contains all relevant libraries for your application.");
+                throw new IllegalStateException("VisualizeHttpCalls annotation could not be read!");
+            }
 
             for (VisualizeHttpsCall visualizeAnnotation : visualizeAnnotations.value()) {
                 endpoints.add(createHttpProducer(visualizeAnnotation, m));

--- a/src/main/java/com/hlag/tools/commvis/domain/service/JmsEndpointScannerImpl.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/service/JmsEndpointScannerImpl.java
@@ -3,6 +3,7 @@ package com.hlag.tools.commvis.domain.service;
 import com.hlag.tools.commvis.analyzer.model.ISenderReceiverCommunication;
 import com.hlag.tools.commvis.analyzer.model.JmsReceiver;
 import com.hlag.tools.commvis.analyzer.service.IScannerService;
+import lombok.extern.slf4j.Slf4j;
 import org.reflections.Reflections;
 import org.reflections.scanners.Scanners;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import java.util.Set;
 import static org.reflections.scanners.Scanners.TypesAnnotated;
 
 @Service
+@Slf4j
 public class JmsEndpointScannerImpl implements IScannerService {
     @Override
     public Collection<ISenderReceiverCommunication> scanSenderAndReceiver(String rootPackageName) {
@@ -26,6 +28,13 @@ public class JmsEndpointScannerImpl implements IScannerService {
 
         classes.forEach(c -> {
             MessageDriven[] annotation = c.getDeclaredAnnotationsByType(MessageDriven.class);
+
+            //as we found classes with the Annotation we must get a result here
+            if (annotation.length == 0) {
+                log.error("Unable to find the annotation, but we found a class with the annotation. Make sure that the classpath contains all relevant libraries for your application.");
+                throw new IllegalStateException("MessageDriven annotation could not be read!");
+            }
+
             String destinationType = null;
             String destination = null;
 


### PR DESCRIPTION
# Description

In case the classpath does not contain all relevant classes of the scanned project, the reflection calls fail and return nothing but we know they should return something. Unfortunately we do not get any indication which class is missing on the classpath.

We add a log message and stop the scan process if we detect this situation.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
