### PR TITLE
feat: add a script to include all dependencies in the classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,16 @@ up-to-date as it is generated automatically based on the current version of the 
 ```shell
 release="1.11.1"
 curl -o analyzer.jar https://github.com/Hapag-Lloyd/dist-comm-vis/releases/download/${RELEASE}/analyzer-${RELEASE}.jar
- 
-java -cp "analyzer.jar;distributed-projects/microservice-a/target/test-classes" org.springframework.boot.loader.JarLauncher scan com.hlag.tools.commvis.example 1 --name=Customer
+
+# make sure that all dependencies are added to the classpath! 
+java -cp "analyzer.jar:distributed-projects/microservice-a/target/test-classes" org.springframework.boot.loader.JarLauncher scan com.hlag.tools.commvis.example 1 --name=Customer
 
 yum install graphviz
 dot -Tpng model.dot > model.png
 ```
 ![Communication](image/communication.png)
 
+For a more sophisticated example checkout the [scan.sh](scripts/scan.sh)
 ## Features
 - extract HTTP(S) consumers: JAX RS
 - extract JMS consumers

--- a/README.md
+++ b/README.md
@@ -22,9 +22,16 @@ java -cp "analyzer.jar:distributed-projects/microservice-a/target/test-classes" 
 yum install graphviz
 dot -Tpng model.dot > model.png
 ```
+
+For a more sophisticated example check the [scan.sh](scripts/scan.sh)
+```shell
+scripts/scan.sh distributed-projects/microservice-a/target 1234 service-a
+scripts/scan.sh distributed-projects/microservice-b/target 2345 service-b
+```
+
 ![Communication](image/communication.png)
 
-For a more sophisticated example checkout the [scan.sh](scripts/scan.sh)
+
 ## Features
 - extract HTTP(S) consumers: JAX RS
 - extract JMS consumers

--- a/distributed-projects/microservice-a/pom.xml
+++ b/distributed-projects/microservice-a/pom.xml
@@ -46,6 +46,25 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/distributed-projects/microservice-b/pom.xml
+++ b/distributed-projects/microservice-b/pom.xml
@@ -46,6 +46,25 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/scripts/scan.sh
+++ b/scripts/scan.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Builds the classpath with all libraries and runs the scanner to produce the model.
+#
+# $1 - path to project to scan. Should contain the jars and classes needed (all dependencies)
+# $2 - project id of your choice
+# $3 - project name of your choice
+#
+# Note: I had troubles to get this running on Windows machines: classpath entries have to be separated by ';' instead of ':'
+#       and the JarLauncher wasn't found.
+# Note: Add the maven-dependency plugin to your project to put all dependencies into a separate folder. See
+#       /distributed-projects/microservice-a/pom.xml
+
+set -euo pipefail
+
+# download latest release
+analyzer_jar_file_name="/tmp/analyzer.jar"
+release_version=$(curl -s https://api.github.com/repos/Hapag-Lloyd/dist-comm-vis/releases/latest | jq .tag_name -r)
+
+curl https://github.com/Hapag-Lloyd/dist-comm-vis/releases/download/"${release_version}"/distcommvis-"${release_version}".jar -o "${analyzer_jar_file_name}" -L
+
+# find all libraries to include
+jars=$(find "$1" -name "*.jar")
+
+classpath=""
+
+for f in $jars; do
+  classpath="$classpath:$f"
+done
+
+# add the scanner downloaded above
+classpath="${classpath:1}:${analyzer_jar_file_name}"
+
+java -cp "${classpath}" org.springframework.boot.loader.JarLauncher scan com.hlag.tools.commvis.example "$2" --name="$3"


### PR DESCRIPTION
# Description

The scanner will work correctly if and only if all dependencies are present in the classpath. This PR adds a script to include all jars of the /target folder to the classpath and then runs the scanner.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
