### PR TITLE
feat: name the model file after the project name if given

### DIFF
--- a/src/main/java/com/hlag/tools/commvis/adapter/in/ScanCommandLine.java
+++ b/src/main/java/com/hlag/tools/commvis/adapter/in/ScanCommandLine.java
@@ -3,7 +3,6 @@ package com.hlag.tools.commvis.adapter.in;
 import com.hlag.tools.commvis.application.port.in.ScannerCommand;
 import com.hlag.tools.commvis.application.port.in.ScannerUseCase;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import picocli.CommandLine;
 
 import java.util.concurrent.Callable;
@@ -19,7 +18,7 @@ public class ScanCommandLine implements Callable<Integer> {
     @CommandLine.Parameters(index = "1", description = "ID of the project to be analyzed. Used to link projects.")
     private String projectId;
 
-    @CommandLine.Option(names = {"-n", "--name"}, defaultValue = "application", description = "Name of the project to be analyzed.")
+    @CommandLine.Option(names = {"-n", "--name"}, defaultValue = "application", description = "Name of the project to be analyzed. This name is appended to the resulting model file.")
     private String projectName;
 
     @Override

--- a/src/main/java/com/hlag/tools/commvis/application/service/ScannerService.java
+++ b/src/main/java/com/hlag/tools/commvis/application/service/ScannerService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -25,6 +26,8 @@ public class ScannerService implements ScannerUseCase {
         Arrays.asList(scannerServices).forEach(s -> endpoints.addAll(s.scanSenderAndReceiver(command.getRootPackage())));
 
         CommunicationModel model = new CommunicationModel(command.getProjectId(), command.getProjectName(), endpoints);
-        Arrays.asList(exportModelServices).forEach(s -> s.export(model, "model"));
+
+        String fileName = Optional.ofNullable(command.getProjectName()).map(pn -> String.format("model-%s", pn)).orElse("model");
+        Arrays.asList(exportModelServices).forEach(s -> s.export(model, fileName));
     }
 }

--- a/src/test/java/com/hlag/tools/commvis/application/service/ScannerServiceTest.java
+++ b/src/test/java/com/hlag/tools/commvis/application/service/ScannerServiceTest.java
@@ -20,7 +20,7 @@ class ScannerServiceTest {
     private IExportModelService exportModelService2;
 
     private ScannerService scannerService;
-    private ScannerCommand command = new ScannerCommand("com.hlag", "4711", "my-project-name");
+    private final ScannerCommand command = new ScannerCommand("com.hlag", "4711", "my-project-name");
 
     @BeforeEach
     void init() {
@@ -43,5 +43,21 @@ class ScannerServiceTest {
 
         Mockito.verify(exportModelService1).export(Mockito.any(), Mockito.any());
         Mockito.verify(exportModelService2).export(Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void shouldUseTheProjectNameAsSuffixForExportedFile_whenScanSenderReceiverAndExport() {
+        scannerService.scanSenderReceiverAndExport(command);
+
+        Mockito.verify(exportModelService1).export(Mockito.any(), Mockito.eq("model-my-project-name"));
+    }
+
+    @Test
+    void shouldNameTheModelFileModel_whenScanSenderReceiverAndExport_givenNoProjectName() {
+        ScannerCommand givenCommand = new ScannerCommand("com.hlag", "4711", null);
+
+        scannerService.scanSenderReceiverAndExport(givenCommand);
+
+        Mockito.verify(exportModelService1).export(Mockito.any(), Mockito.eq("model"));
     }
 }


### PR DESCRIPTION
# Description

The project name (`--name my-project-name`) is appended to the name of the model file. If the project name is not set `model` is used as file name.

Very useful if multiple projects are scanned. Using the project name you ensure that the models do not overwrite each other.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
