### PR TITLE
feat: extract SQS consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ scripts/scan.sh distributed-projects/microservice-b/target 2345 service-b
 - extract HTTP(S) consumers: JAX RS, Spring
 - extract JMS consumers
 - extract producers via special annotation: HTTP(S)
+- extract consumers via special annotation: SQS
 - write a `model.json` file
 - write a `model.dot` file for [GraphViz](https://gitlab.com/graphviz/graphviz)
 - support user defined scanners (see https://github.com/Hapag-Lloyd/dist-comm-vis-api)
@@ -45,4 +46,4 @@ scripts/scan.sh distributed-projects/microservice-b/target 2345 service-b
 - extract Kafka consumers and producers
 - extract JMS producers
 - extract SNS producers
-- extract SQS consumers and producers
+- extract SQS producers

--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>com.hlag.tools.commvis</groupId>
             <artifactId>api</artifactId>
-            <version>2.4.0</version>
+            <version>2.5.0</version>
         </dependency>
         <dependency>
             <groupId>javax.ejb</groupId>

--- a/src/main/java/com/hlag/tools/commvis/application/port/out/DotCommunicationModelVisitor.java
+++ b/src/main/java/com/hlag/tools/commvis/application/port/out/DotCommunicationModelVisitor.java
@@ -51,4 +51,14 @@ public class DotCommunicationModelVisitor extends AbstractCommunicationModelVisi
 
         ++nodes;
     }
+
+    @Override
+    public void visit(SqsConsumer sqsConsumer) {
+        String label = sqsConsumer.getClassName() + "\\n" + sqsConsumer.getMethodName() + "\\n" + sqsConsumer.getQueueName();
+        nodeDefinitions.append(String.format("  \"%d\" [label=\"%s\" shape=\"diamond\"]\n", nodes, label));
+
+        graphDefinitions.append(String.format("  \"%d\" -> \"application\"\n", nodes));
+
+        ++nodes;
+    }
 }

--- a/src/main/java/com/hlag/tools/commvis/application/service/CombineService.java
+++ b/src/main/java/com/hlag/tools/commvis/application/service/CombineService.java
@@ -105,6 +105,9 @@ public class CombineService implements CombineUseCase {
             nodeDefinitions.append(String.format("  \"%s\" [label=\"%s\" shape=\"diamond\"]\n", id, label));
             graphDefinitions.append(String.format("  \"%s\" -> \"%s\"\n", id, modelId));
         }
+
+        @Override
+        public void visit(SqsConsumer sqsConsumer) {}
     }
 
     @RequiredArgsConstructor
@@ -138,5 +141,8 @@ public class CombineService implements CombineUseCase {
         public void visit(JmsReceiver jmsReceiver) {
 
         }
+
+        @Override
+        public void visit(SqsConsumer sqsConsumer) {}
     }
 }

--- a/src/main/java/com/hlag/tools/commvis/application/service/CombineService.java
+++ b/src/main/java/com/hlag/tools/commvis/application/service/CombineService.java
@@ -4,7 +4,6 @@ import com.hlag.tools.commvis.adapter.in.CommunicationModelFromJsonFileAdapter;
 import com.hlag.tools.commvis.analyzer.model.*;
 import com.hlag.tools.commvis.application.port.in.CombineCommand;
 import com.hlag.tools.commvis.application.port.in.CombineUseCase;
-import com.sun.org.apache.xpath.internal.operations.Mod;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +24,7 @@ public class CombineService implements CombineUseCase {
 
         // find all model files and read them
         modelReader.getModelFiles(command.getBaseDirectory()).forEach(p -> {
-             CommunicationModel model = modelReader.getModelFromFile(p);
+            CommunicationModel model = modelReader.getModelFromFile(p);
             models.put(model.getProjectId(), model);
         });
 
@@ -71,7 +70,7 @@ public class CombineService implements CombineUseCase {
 
         @Override
         public void visit(HttpConsumer consumer) {
-            String label = consumer.getClassName() + "." + consumer.getMethodName() + "\\n" + consumer.getPath() + "\\n" + consumer.getType();
+            String label = String.format("%s.%s\\n%s\\n%s", consumer.getClassName(), consumer.getMethodName(), consumer.getPath(), consumer.getType();
             String id = String.format("%s#%s", modelId, consumer.getId());
 
             nodeDefinitions.append(String.format("  \"%s\" [label=\"%s\" shape=\"ellipse\"]\n", id, label));
@@ -99,7 +98,7 @@ public class CombineService implements CombineUseCase {
 
         @Override
         public void visit(JmsReceiver endpoint) {
-            String label = endpoint.getClassName() + "\\n" + endpoint.getDestination() + "\\n" + endpoint.getDestinationType();
+            String label = String.format("%s\\n%s\\n%s", endpoint.getClassName(), endpoint.getDestination(), endpoint.getDestinationType());
             String id = String.format("%s#%s", modelId, endpoint.getId());
 
             nodeDefinitions.append(String.format("  \"%s\" [label=\"%s\" shape=\"diamond\"]\n", id, label));
@@ -107,7 +106,13 @@ public class CombineService implements CombineUseCase {
         }
 
         @Override
-        public void visit(SqsConsumer sqsConsumer) {}
+        public void visit(SqsConsumer sqsConsumer) {
+            String label = String.format("%s\\n%s\\n%s", sqsConsumer.getClassName(), sqsConsumer.getMethodName(), sqsConsumer.getQueueName());
+            String id = String.format("%s#%s", modelId, sqsConsumer.getId());
+
+            nodeDefinitions.append(String.format("  \"%s\" [label=\"%s\" shape=\"diamond\"]\n", id, label));
+            graphDefinitions.append(String.format("  \"%s\" -> \"%s\"\n", id, modelId));
+        }
     }
 
     @RequiredArgsConstructor
@@ -143,6 +148,7 @@ public class CombineService implements CombineUseCase {
         }
 
         @Override
-        public void visit(SqsConsumer sqsConsumer) {}
+        public void visit(SqsConsumer sqsConsumer) {
+        }
     }
 }

--- a/src/main/java/com/hlag/tools/commvis/application/service/CombineService.java
+++ b/src/main/java/com/hlag/tools/commvis/application/service/CombineService.java
@@ -45,8 +45,8 @@ public class CombineService implements CombineUseCase {
             graphDefinitions.append(visitor.getGraphDefinitions().toString());
         });
 
-        dotModel.append(nodeDefinitions.toString());
-        dotModel.append(graphDefinitions.toString());
+        dotModel.append(nodeDefinitions);
+        dotModel.append(graphDefinitions);
         dotModel.append("}");
 
         return dotModel.toString();
@@ -70,7 +70,7 @@ public class CombineService implements CombineUseCase {
 
         @Override
         public void visit(HttpConsumer consumer) {
-            String label = String.format("%s.%s\\n%s\\n%s", consumer.getClassName(), consumer.getMethodName(), consumer.getPath(), consumer.getType();
+            String label = String.format("%s.%s\\n%s\\n%s", consumer.getClassName(), consumer.getMethodName(), consumer.getPath(), consumer.getType());
             String id = String.format("%s#%s", modelId, consumer.getId());
 
             nodeDefinitions.append(String.format("  \"%s\" [label=\"%s\" shape=\"ellipse\"]\n", id, label));

--- a/src/main/java/com/hlag/tools/commvis/domain/service/SqsConsumerScannerImpl.java
+++ b/src/main/java/com/hlag/tools/commvis/domain/service/SqsConsumerScannerImpl.java
@@ -1,0 +1,78 @@
+package com.hlag.tools.commvis.domain.service;
+
+import com.hlag.tools.commvis.analyzer.annotation.VisualizeHttpsCall;
+import com.hlag.tools.commvis.analyzer.annotation.VisualizeSqsConsumer;
+import com.hlag.tools.commvis.analyzer.annotation.VisualizeSqsConsumers;
+import com.hlag.tools.commvis.analyzer.model.EndpointFactory;
+import com.hlag.tools.commvis.analyzer.model.HttpProducer;
+import com.hlag.tools.commvis.analyzer.model.ISenderReceiverCommunication;
+import com.hlag.tools.commvis.analyzer.model.SqsConsumer;
+import com.hlag.tools.commvis.analyzer.service.IScannerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.reflections.Reflections;
+import org.reflections.scanners.Scanners;
+import org.springframework.stereotype.Service;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.reflections.scanners.Scanners.MethodsAnnotated;
+
+/**
+ * Scans the classpath for incoming SQS events. Methods consuming these events have to be annotated with
+ * {@code VisualizeSqsConsumer}.
+ *
+ * @see com.hlag.tools.commvis.analyzer.annotation.VisualizeSqsConsumer
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SqsConsumerScannerImpl implements IScannerService {
+    private final EndpointFactory endpointFactory;
+
+    @Override
+    public Collection<ISenderReceiverCommunication> scanSenderAndReceiver(String rootPackageName) {
+        Set<ISenderReceiverCommunication> endpoints = new HashSet<>();
+        Reflections reflections = new Reflections(rootPackageName, Scanners.values());
+
+        Set<Method> methods = reflections.get(MethodsAnnotated.with(VisualizeSqsConsumer.class).as(Method.class));
+
+        methods.forEach(m -> {
+            VisualizeSqsConsumer visualizeAnnotation = m.getDeclaredAnnotation(VisualizeSqsConsumer.class);
+
+            //as we found methods with the Annotation we must get a result here
+            if (visualizeAnnotation == null) {
+                log.error("Unable to find the annotation, but we found a method with the annotation. Make sure that the classpath contains all relevant libraries for your application.");
+                throw new IllegalStateException("VisualizeHttpCall annotation could not be read!");
+            }
+
+            endpoints.add(createSqsConsumer(visualizeAnnotation, m));
+        });
+
+        methods = reflections.get(MethodsAnnotated.with(VisualizeSqsConsumers.class).as(Method.class));
+        methods.forEach(m -> {
+            VisualizeSqsConsumers visualizeAnnotations = m.getDeclaredAnnotation(VisualizeSqsConsumers.class);
+
+            //as we found methods with the Annotation we must get a result here
+            if (visualizeAnnotations == null) {
+                log.error("Unable to find the annotation, but we found a method with the annotation. Make sure that the classpath contains all relevant libraries for your application.");
+                throw new IllegalStateException("VisualizeHttpCalls annotation could not be read!");
+            }
+
+            for (VisualizeSqsConsumer visualizeAnnotation : visualizeAnnotations.value()) {
+                endpoints.add(createSqsConsumer(visualizeAnnotation, m));
+            }
+        });
+
+        log.info("Outgoing HTTP calls found: {}", endpoints.size());
+
+        return endpoints;
+    }
+
+    private SqsConsumer createSqsConsumer(VisualizeSqsConsumer annotation, Method method) {
+        return endpointFactory.createSqsReceiver(method.getDeclaringClass().getCanonicalName(), method.getName(), annotation.queueName());
+    }
+}

--- a/src/test/java/com/hlag/tools/commvis/domain/service/HttpEndpointProducerScannerImplTest.java
+++ b/src/test/java/com/hlag/tools/commvis/domain/service/HttpEndpointProducerScannerImplTest.java
@@ -3,7 +3,6 @@ package com.hlag.tools.commvis.domain.service;
 import com.hlag.tools.commvis.analyzer.model.EndpointFactory;
 import com.hlag.tools.commvis.analyzer.model.HttpProducer;
 import com.hlag.tools.commvis.analyzer.model.ISenderReceiverCommunication;
-import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -11,10 +10,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import javax.xml.stream.events.EndDocument;
 import java.util.Collection;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class HttpEndpointProducerScannerImplTest {
     @Mock

--- a/src/test/java/com/hlag/tools/commvis/domain/service/SqsConsumerScannerImplTest.java
+++ b/src/test/java/com/hlag/tools/commvis/domain/service/SqsConsumerScannerImplTest.java
@@ -1,0 +1,40 @@
+package com.hlag.tools.commvis.domain.service;
+
+import com.hlag.tools.commvis.analyzer.model.EndpointFactory;
+import com.hlag.tools.commvis.analyzer.model.HttpProducer;
+import com.hlag.tools.commvis.analyzer.model.ISenderReceiverCommunication;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collection;
+
+class SqsConsumerScannerImplTest {
+    @Mock
+    private EndpointFactory endpointFactory;
+
+    @InjectMocks
+    private SqsConsumerScannerImpl clazz;
+
+    @BeforeEach
+    public void init() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void shouldFindAllSqsConsunmers_whenScanClasspath() {
+        Collection<ISenderReceiverCommunication> actualEndpoints = clazz.scanSenderAndReceiver("test.sqs.visualize");
+
+        Mockito.verify(endpointFactory, Mockito.times(3)).createSqsReceiver(Mockito.any(), Mockito.any(), Mockito.any());
+    }
+
+    @Test
+    void shouldExtractAllHttpProducerInformation_whenScanClasspath() {
+        Collection<HttpProducer> actualEndpoints = (Collection) clazz.scanSenderAndReceiver("test.sqs.visualize");
+
+        Mockito.verify(endpointFactory, Mockito.times(1)).createSqsReceiver(Mockito.eq("test.sqs.visualize.SqsReceiver"), Mockito.eq("receiveLocationSyncEvent"), Mockito.eq("locations"));
+    }
+}

--- a/src/test/java/com/hlag/tools/commvis/domain/service/UserDefinedScannerIT.java
+++ b/src/test/java/com/hlag/tools/commvis/domain/service/UserDefinedScannerIT.java
@@ -19,6 +19,6 @@ public class UserDefinedScannerIT {
     @Test
     //TODO this test is strange as we add the service above and check that it's there.
     void shouldFindUSerDefinedScannersInPackage()  {
-        assertThat(scannerServices).hasSize(5);
+        assertThat(scannerServices).hasSize(6);
     }
 }

--- a/src/test/java/test/sqs/visualize/SqsReceiver.java
+++ b/src/test/java/test/sqs/visualize/SqsReceiver.java
@@ -1,0 +1,16 @@
+package test.sqs.visualize;
+
+import com.hlag.tools.commvis.analyzer.annotation.VisualizeSqsConsumer;
+import com.hlag.tools.commvis.analyzer.annotation.VisualizeSqsConsumers;
+
+public class SqsReceiver {
+    @VisualizeSqsConsumer(queueName = "locations", projectName = "master data")
+    public void receiveLocationSyncEvent() {
+
+    }
+
+    @VisualizeSqsConsumers({@VisualizeSqsConsumer(queueName = "customer_data", projectName = "master data"), @VisualizeSqsConsumer(queueName = "account_data", projectName = "master data")})
+    public void receiveFromManyQueues() {
+
+    }
+}


### PR DESCRIPTION
# Description

Scans the classpath for `@VisualizeSqsConsumer` annotations to visualize all consumers of SQS messages. The property `sqs_consumer` is added to `model.json`.

# Checklist

- [x] My code follows the style guidelines of the project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
