### PR TITLE
chore: use PAT to auto-approve Renovate PRs

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -1,0 +1,33 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "cpus",
+    "Hapag",
+    "Infracost",
+    "oidc",
+    "Repology",
+    "tflint",
+    "tfsec"
+  ],
+  "ignoreWords": [
+    "amannn",
+    "codeowners",
+    "codeql",
+    "datasource",
+    "dorny",
+    "hmarr",
+    "ibiqlik",
+    "kayman",
+    "ludeeus",
+    "markdownlint",
+    "mktemp",
+    "rhysd",
+    "ruleset",
+    "sarif",
+    "shellcheck",
+    "shuf",
+    "shunsuke",
+    "signoff"
+  ]
+}

--- a/.github/workflows/renovate-auto-approve.yml
+++ b/.github/workflows/renovate-auto-approve.yml
@@ -1,0 +1,17 @@
+---
+name: Approve all Renovate PRs automatically
+
+# yamllint disable-line rule:truthy
+on: pull_request_target
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: github.actor == 'renovate[bot]'
+    steps:
+      - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4  # v3.2.1
+        with:
+          review-message: "Auto approved Renovate PR by organization"
+          github-token: ${{ secrets.PAT_FOR_PR_AUTO_APPROVAL }}

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -1,5 +1,5 @@
 ---
-name: 'Check spelling'
+name: "Check spelling"
 
 # yamllint disable-line rule:truthy
 on:
@@ -13,6 +13,6 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       # yamllint disable-line rule:comments
-      - uses: streetsidesoftware/cspell-action@52cba17693dc12d7d8f521631037008a17c93e53 # v5.0.0
+      - uses: streetsidesoftware/cspell-action@6043e383e6abacdc8b8a0d97756586da8d0d985d # v5.1.0
         with:
-          config: .cspell.json
+          config: .config/cspell.json


### PR DESCRIPTION
Uses the new PAT `secrets.PAT_FOR_PR_AUTO_APPROVAL` to approve Renovate PRs. Temporary created access tokens via GitHub App do not work here as the app is not a valid approver.

To use the auto-merge feature, make sure that the owner of the PAT is in the list of approvers.